### PR TITLE
make create-large-file run about 5x-6x faster

### DIFF
--- a/create-large-file.pl6
+++ b/create-large-file.pl6
@@ -41,7 +41,7 @@ my $ofil = "large-{$siz}-{$txt}-file.txt";
 
 # how many (lines) iterations needed?
 my $slen   = $str.chars;
-my $nlines = $siz * $mul / $slen;
+my $nlines = $siz * $mul div $slen;
 
 say "Requested file size: $siz $txt";
 say "String size:  $slen";


### PR DESCRIPTION
by using an Int as the endpoint of the range rather than a Rat.
